### PR TITLE
Add brief note on PAT documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ See example client instantiations and requests in [example_test.go](pkg/example_
 
 ⚠️ **Note**: This SDK is not yet stable. Breaking changes may occur at any time.
 
+### Authentication
+
+Currently, this SDK supports both [Personal Access Tokens (classic)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#personal-access-tokens-classic) and [fine-grained Personal Access Tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#fine-grained-personal-access-tokens).
+
+Future work is planned for the SDK to support [GitHub Apps](https://docs.github.com/en/apps/overview) authentication as well.
+
 ## Why a generated SDK?
 
 We want to...


### PR DESCRIPTION
This small PR adds a note on what types of authentication are supported by the SDK. 

Nick: do you think I should take out the note about future work planned for GitHub Apps? 